### PR TITLE
Hotfix/docker compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 */**/node_modules
 */**/dist
 migrations/*prod*
+.idea

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,24 +2,23 @@ services:
   postgres:
     image: postgres:14-alpine
     restart: unless-stopped
-    network_mode: "host"
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=cic_graph
     volumes:
+      - ../migrations/001_cic_graph_init.sql:/docker-entrypoint-initdb.d/001_cic_graph_init.sql
       - cic-graph-db:/var/lib/postgresql/data
     ports:
       - '5432:5432'
   hasura:
     image: hasura/graphql-engine:v2.8.3
     restart: unless-stopped
-    network_mode: "host"
     depends_on:
       - postgres
     environment:
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:postgres@localhost:5432/cic_graph
-      PG_DATABASE_URL: postgres://postgres:postgres@localhost:5432/cic_graph
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:postgres@postgres:5432/cic_graph
+      PG_DATABASE_URL: postgres://postgres:postgres@postgres:5432/cic_graph
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_ADMIN_SECRET: admin
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: anonymous

--- a/migrations/001_cic_graph_init.sql
+++ b/migrations/001_cic_graph_init.sql
@@ -150,13 +150,4 @@ CREATE TABLE IF NOT EXISTS services_ratings (
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
----- create above / drop below ----
-
-DROP TABLE IF EXISTS
-services_ratings, services_images,services, services,
-service_accepted_payment, voucher_certifications, voucher_backers
-vouchers, marketplaces, accounts,
-personal_information, users;
-
-DROP TABLE IF EXISTS
-interface_type, service_type, account_type;
+---- create above


### PR DESCRIPTION
- Removes drop instructions to keep tables that have been bootstrapped.
- Remove `network_mode` and rely on port bindings.
- Rename host in Postgres URL definitions to use Postgres service name (https://stackoverflow.com/questions/56254196/connection-error-accessing-postgres-docker-container).
- Add a reference to the migration script to create cic_graph tables.
- Add JetBrains idea folder to .gitignore.