### PR TITLE
feat: add gas gift status, gas gift approver

### DIFF
--- a/metadata/databases/cic_graph/tables/public_gas_gift_status_type.yaml
+++ b/metadata/databases/cic_graph/tables/public_gas_gift_status_type.yaml
@@ -1,0 +1,4 @@
+table:
+  name: gas_gift_status_type
+  schema: public
+is_enum: true

--- a/metadata/databases/cic_graph/tables/tables.yaml
+++ b/metadata/databases/cic_graph/tables/tables.yaml
@@ -3,6 +3,7 @@
 - "!include public_accounts.yaml"
 - "!include public_commodity_listings.yaml"
 - "!include public_commodity_type.yaml"
+- "!include public_gas_gift_status_type.yaml"
 - "!include public_gender_type.yaml"
 - "!include public_interface_type.yaml"
 - "!include public_marketplaces.yaml"

--- a/migrations/009_gas_gift.sql
+++ b/migrations/009_gas_gift.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS gas_gift_status_type (
+  value TEXT PRIMARY KEY
+);
+INSERT INTO gas_gift_status_type (value) VALUES
+('APPROVED'),
+('REQUESTED'),
+('REJECTED'),
+('NONE');
+
+ALTER TABLE accounts ADD COLUMN gas_gift_status TEXT REFERENCES gas_gift_status_type(value) DEFAULT 'NONE' NOT NULL;
+
+ALTER TABLE accounts ADD COLUMN gas_approver INT REFERENCES accounts(id);

--- a/migrations/cic_graph/1699422690072_gas_gift/down.sql
+++ b/migrations/cic_graph/1699422690072_gas_gift/down.sql
@@ -1,0 +1,14 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TABLE IF NOT EXISTS gas_gift_status_type (
+--   value TEXT PRIMARY KEY
+-- );
+-- INSERT INTO gas_gift_status_type (value) VALUES
+-- ('APPROVED'),
+-- ('REQUESTED'),
+-- ('REJECTED'),
+-- ('NONE');
+--
+-- ALTER TABLE accounts ADD COLUMN gas_gift_status TEXT REFERENCES gas_gift_status_type(value) DEFAULT 'NONE' NOT NULL;
+--
+-- ALTER TABLE accounts ADD COLUMN gas_approver INT REFERENCES accounts(id);

--- a/migrations/cic_graph/1699422690072_gas_gift/up.sql
+++ b/migrations/cic_graph/1699422690072_gas_gift/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS gas_gift_status_type (
+  value TEXT PRIMARY KEY
+);
+INSERT INTO gas_gift_status_type (value) VALUES
+('APPROVED'),
+('REQUESTED'),
+('REJECTED'),
+('NONE');
+
+ALTER TABLE accounts ADD COLUMN gas_gift_status TEXT REFERENCES gas_gift_status_type(value) DEFAULT 'NONE' NOT NULL;
+
+ALTER TABLE accounts ADD COLUMN gas_approver INT REFERENCES accounts(id);


### PR DESCRIPTION
```
GASGIFTER_STATUS: Approved | Requested | Rejected | None? (@default None)
    Checking if registered could be done on the front-end (registry.isActive)

GASGIFTER_APPROVER: Account (Only Staff or Admin)
```